### PR TITLE
Adding the `npm i` to install dependencies before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ webterm init
 
 # build the extension
 cd extension
+npm i
 npm run build
 ```
 


### PR DESCRIPTION
On a new clone, the user will not be able to run `npm run build` until they first run `npm i`.